### PR TITLE
added handling for multiple-byte length of num_len_bytes

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -37,8 +37,9 @@ def reader(f,q):
             else:
                 num_len_bytes = ord(length_key)-128
                 length, buffer = read_into_buffer(f,num_len_bytes,buffer)
+                length = int.from_bytes(length, "big")
 
-            _, buffer = read_into_buffer(f,ord(length),buffer) # reads value packet and stores into buffer
+            _, buffer = read_into_buffer(f,length,buffer) # reads value packet and stores into buffer
             q.put(buffer)
             buffer=b''
                     


### PR DESCRIPTION
ord() does not work with more than one byte, so if long flag is present in BER then it will fail. Added int.from_bytes method to decode into value length. 